### PR TITLE
BDN config for running against local build of FSharp.Core.dll

### DIFF
--- a/StringLengthOptim/Bench.fs
+++ b/StringLengthOptim/Bench.fs
@@ -10,6 +10,7 @@ open Microsoft.FSharp.NativeInterop
 open System.Text
 open System.Runtime.InteropServices
 open System.Buffers
+open System.Diagnostics
 
 module Data =
     let get value =
@@ -41,15 +42,6 @@ module StringLength=
 
 
 
-[<MaxRelativeError(0.01)>]
-//[<MaxWarmupCount(5); MinWarmupCount(2)>]
-//[<IterationTime(120.)>]
-//[<MaxIterationCount 30; MinIterationCount 5>]
-//[<LegacyJitX64Job>]
-//[<LegacyJitX86Job>]
-//[<RyuJitX86Job>] (not available???)
-//[<RyuJitX64Job>]
-[<SimpleJob(RuntimeMoniker.NetCoreApp31)>]
 [<MemoryDiagnoser>]
 [<CategoriesColumn; RankColumn>]
 //[<GroupBenchmarksBy([|BenchmarkLogicalGroupRule.ByCategory|])>]
@@ -61,6 +53,13 @@ type BenchLength() =
     //[<Params(0, 1, 2, 10)>]
     [<Params(1)>]
     val mutable Size: int
+
+    [<GlobalSetup>]
+    member this.PrintAssemblyPath() =
+        let asm = typeof<FSharp.Core.EntryPointAttribute>.Assembly
+        let version = FileVersionInfo.GetVersionInfo(asm.Location)
+        printfn "Assembly: %A" (asm.CodeBase)
+        printfn "Version: %A" (version.FileVersion)
 
     [<Benchmark(OperationsPerInvoke=10_000, Baseline = true)>]
     member this.optimized() =

--- a/StringLengthOptim/Program.fs
+++ b/StringLengthOptim/Program.fs
@@ -1,14 +1,28 @@
 ﻿// Learn more about F# at http://fsharp.org
 
-open System
+open BenchmarkDotNet.Configs
+open BenchmarkDotNet.Jobs
 open BenchmarkDotNet.Running
 open FSharp.Perf
+open Perfolizer.Horology
 
 [<EntryPoint>]
 let main argv =
     let asm = typeof<FSharp.Core.EntryPointAttribute>.Assembly
     printfn "Assembly: %A" (asm.CodeBase)
-    BenchmarkRunner.Run<BenchLength>()
+
+    let baseJob = Job.Default
+                    .WithWarmupCount(1) // 1 warmup is enough for our purpose
+                    .WithIterationTime(TimeInterval.FromMilliseconds(250.0)) // the default is 0.5s per iteration
+                    .WithMaxRelativeError(0.01)
+
+    let jobBefore = baseJob.WithId("Before");
+
+    let jobAfter = baseJob.WithCustomBuildConfiguration("LocalBuild").WithId("After");
+
+    let config = DefaultConfig.Instance.AddJob(jobBefore).AddJob(jobAfter).KeepBenchmarkFiles()
+
+    BenchmarkRunner.Run<BenchLength>(config)
     |> ignore
     
     0 // return an integer exit code

--- a/StringLengthOptim/StringLengthOptim.fsproj
+++ b/StringLengthOptim/StringLengthOptim.fsproj
@@ -3,12 +3,12 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <!-- only "Release" builds are optimized by default -->
+    <Optimize>true</Optimize>
+    <DisableImplicitFSharpCoreReference Condition=" '$(Configuration)' == 'LocalBuild' ">true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="deps\FSharp.Core.xml" />
-    <Content Include="deps\FSharp.Core.dll" />
     <Compile Include="Bench.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
@@ -21,7 +21,9 @@
     <Reference Include="FSharp.Core" />
   </ItemGroup>
     
-  <ItemGroup>
+  <ItemGroup Condition=" '$(Configuration)' == 'LocalBuild' ">
+    <Content Include="deps\FSharp.Core.xml" />
+    <Content Include="deps\FSharp.Core.dll" />
     <Reference Update="FSharp.Core">
       <HintPath>deps\FSharp.Core.dll</HintPath>
     </Reference>


### PR DESCRIPTION
BDN runs every benchmark for every job defined in the config

Every job can contain some custom settings, including configuration passed to MsBuild when building the auto-generated project.

So by using:

```fs
job.WithCustomBuildConfiguration("LocalBuild")
```

and

```xml
<ItemGroup Condition=" '$(Configuration)' == 'LocalBuild' ">
```

we can control the msbuild settings per BDN job

How to run the benchmarks:

```cmd
dotnet run -c Release
```

Sample results:

|    Method |    Job | BuildConfiguration | Size |      Mean |     Error |    StdDev | Ratio | Rank | Code Size | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |------- |------------------- |----- |----------:|----------:|----------:|------:|-----:|----------:|------:|------:|------:|----------:|
| optimized |  After |         LocalBuild |    1 | 0.2644 ns | 0.0022 ns | 0.0020 ns |  1.00 |    1 |     217 B |     - |     - |     - |         - |
|  original |  After |         LocalBuild |    1 | 0.3981 ns | 0.0039 ns | 0.0038 ns |  1.51 |    2 |     223 B |     - |     - |     - |         - |
|  nullOnly |  After |         LocalBuild |    1 | 0.2640 ns | 0.0024 ns | 0.0023 ns |  1.00 |    1 |     217 B |     - |     - |     - |         - |
| nullRefEq |  After |         LocalBuild |    1 | 0.2635 ns | 0.0023 ns | 0.0020 ns |  1.00 |    1 |     217 B |     - |     - |     - |         - |
|           |        |                    |      |           |           |           |       |      |           |       |       |       |           |
| optimized | Before |            Default |    1 | 0.3980 ns | 0.0038 ns | 0.0059 ns |  1.00 |    2 |     223 B |     - |     - |     - |         - |
|  original | Before |            Default |    1 | 0.3988 ns | 0.0039 ns | 0.0040 ns |  0.99 |    2 |     223 B |     - |     - |     - |         - |
|  nullOnly | Before |            Default |    1 | 0.2640 ns | 0.0021 ns | 0.0021 ns |  0.66 |    1 |     217 B |     - |     - |     - |         - |
| nullRefEq | Before |            Default |    1 | 0.2641 ns | 0.0014 ns | 0.0014 ns |  0.66 |    1 |     217 B |     - |     - |     - |         - |

Full log with detailed .dll version printed to console (to verify we are using the thing we think we are using):

<details>

```log
Assembly: "file:///C:/Projects/forks/StringLength-Optimization/StringLengthOptim/bin/Release/netcoreapp3.1/FSharp.Core.dll"
// Validating benchmarks:
// ***** BenchmarkRunner: Start   *****
// ***** Found 8 benchmark(s) in total *****
// ***** Building 2 exe(s) in Parallel: Start   *****
// ***** Done, took 00:00:17 (17.5 sec)   *****
// Found 8 benchmarks:
//   BenchLength.optimized: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
//   BenchLength.original: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
//   BenchLength.nullOnly: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
//   BenchLength.nullRefEq: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
//   BenchLength.optimized: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
//   BenchLength.original: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
//   BenchLength.nullOnly: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
//   BenchLength.nullRefEq: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]

// **************************
// Benchmark: BenchLength.optimized: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
// *** Execute ***
// Launch: 1 / 1
// Execute: dotnet "After.dll" --benchmarkName "FSharp.Perf.BenchLength.optimized(Size: 1)" --job "After" --benchmarkId 0 in C:\Projects\forks\StringLength-Optimization\StringLengthOptim\bin\Release\netcoreapp3.1\After\bin\LocalBuild\netcoreapp3.1
// BeforeAnythingElse

// Benchmark Process Environment Information:
// Runtime=.NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT DEBUG
// GC=Concurrent Workstation
// Job: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1)

Assembly: "file:///C:/Projects/forks/StringLength-Optimization/StringLengthOptim/bin/Release/netcoreapp3.1/After/bin/LocalBuild/netcoreapp3.1/FSharp.Core.dll"
Version: "42.42.42.42424"
OverheadJitting  1: 10000 op, 271700.00 ns, 27.1700 ns/op
WorkloadJitting  1: 10000 op, 365100.00 ns, 36.5100 ns/op

OverheadJitting  2: 160000 op, 179500.00 ns, 1.1219 ns/op
WorkloadJitting  2: 160000 op, 213400.00 ns, 1.3337 ns/op

WorkloadPilot    1: 160000 op, 45700.00 ns, 0.2856 ns/op
WorkloadPilot    2: 875360000 op, 232730700.00 ns, 0.2659 ns/op
WorkloadPilot    3: 940320000 op, 250452300.00 ns, 0.2663 ns/op
WorkloadPilot    4: 938720000 op, 250016200.00 ns, 0.2663 ns/op

OverheadWarmup   1: 938720000 op, 210200.00 ns, 0.0002 ns/op
OverheadWarmup   2: 938720000 op, 207900.00 ns, 0.0002 ns/op
OverheadWarmup   3: 938720000 op, 206400.00 ns, 0.0002 ns/op
OverheadWarmup   4: 938720000 op, 206500.00 ns, 0.0002 ns/op
OverheadWarmup   5: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadWarmup   6: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadWarmup   7: 938720000 op, 206300.00 ns, 0.0002 ns/op

OverheadActual   1: 938720000 op, 207900.00 ns, 0.0002 ns/op
OverheadActual   2: 938720000 op, 206400.00 ns, 0.0002 ns/op
OverheadActual   3: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadActual   4: 938720000 op, 207800.00 ns, 0.0002 ns/op
OverheadActual   5: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadActual   6: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadActual   7: 938720000 op, 207500.00 ns, 0.0002 ns/op
OverheadActual   8: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadActual   9: 938720000 op, 206200.00 ns, 0.0002 ns/op
OverheadActual  10: 938720000 op, 204700.00 ns, 0.0002 ns/op
OverheadActual  11: 938720000 op, 206400.00 ns, 0.0002 ns/op
OverheadActual  12: 938720000 op, 204700.00 ns, 0.0002 ns/op
OverheadActual  13: 938720000 op, 206200.00 ns, 0.0002 ns/op
OverheadActual  14: 938720000 op, 206200.00 ns, 0.0002 ns/op
OverheadActual  15: 938720000 op, 206100.00 ns, 0.0002 ns/op

WorkloadWarmup   1: 938720000 op, 250269400.00 ns, 0.2666 ns/op

// BeforeActualRun
WorkloadActual   1: 938720000 op, 250153800.00 ns, 0.2665 ns/op
WorkloadActual   2: 938720000 op, 250554800.00 ns, 0.2669 ns/op
WorkloadActual   3: 938720000 op, 249943200.00 ns, 0.2663 ns/op
WorkloadActual   4: 938720000 op, 250232100.00 ns, 0.2666 ns/op
WorkloadActual   5: 938720000 op, 250411800.00 ns, 0.2668 ns/op
WorkloadActual   6: 938720000 op, 249978700.00 ns, 0.2663 ns/op
WorkloadActual   7: 938720000 op, 251001900.00 ns, 0.2674 ns/op
WorkloadActual   8: 938720000 op, 247116800.00 ns, 0.2632 ns/op
WorkloadActual   9: 938720000 op, 246125400.00 ns, 0.2622 ns/op
WorkloadActual  10: 938720000 op, 246357400.00 ns, 0.2624 ns/op
WorkloadActual  11: 938720000 op, 247624000.00 ns, 0.2638 ns/op
WorkloadActual  12: 938720000 op, 246929300.00 ns, 0.2630 ns/op
WorkloadActual  13: 938720000 op, 247430500.00 ns, 0.2636 ns/op
WorkloadActual  14: 938720000 op, 246966000.00 ns, 0.2631 ns/op
WorkloadActual  15: 938720000 op, 245794900.00 ns, 0.2618 ns/op

// AfterActualRun
WorkloadResult   1: 938720000 op, 249947500.00 ns, 0.2663 ns/op
WorkloadResult   2: 938720000 op, 250348500.00 ns, 0.2667 ns/op
WorkloadResult   3: 938720000 op, 249736900.00 ns, 0.2660 ns/op
WorkloadResult   4: 938720000 op, 250025800.00 ns, 0.2663 ns/op
WorkloadResult   5: 938720000 op, 250205500.00 ns, 0.2665 ns/op
WorkloadResult   6: 938720000 op, 249772400.00 ns, 0.2661 ns/op
WorkloadResult   7: 938720000 op, 250795600.00 ns, 0.2672 ns/op
WorkloadResult   8: 938720000 op, 246910500.00 ns, 0.2630 ns/op
WorkloadResult   9: 938720000 op, 245919100.00 ns, 0.2620 ns/op
WorkloadResult  10: 938720000 op, 246151100.00 ns, 0.2622 ns/op
WorkloadResult  11: 938720000 op, 247417700.00 ns, 0.2636 ns/op
WorkloadResult  12: 938720000 op, 246723000.00 ns, 0.2628 ns/op
WorkloadResult  13: 938720000 op, 247224200.00 ns, 0.2634 ns/op
WorkloadResult  14: 938720000 op, 246759700.00 ns, 0.2629 ns/op
WorkloadResult  15: 938720000 op, 245588600.00 ns, 0.2616 ns/op
GC:  0 0 0 480 938720000
Threading:  2 0 938720000

// AfterAll
// Benchmark Process 14196 has exited with code 0

Mean = 0.264 ns, StdErr = 0.001 ns (0.20%), N = 15, StdDev = 0.002 ns
Min = 0.262 ns, Q1 = 0.263 ns, Median = 0.264 ns, Q3 = 0.266 ns, Max = 0.267 ns
IQR = 0.003 ns, LowerFence = 0.258 ns, UpperFence = 0.271 ns
ConfidenceInterval = [0.262 ns; 0.267 ns] (CI 99.9%), Margin = 0.002 ns (0.82% of Mean)
Skewness = 0.01, Kurtosis = 1.13, MValue = 2

// **************************
// Benchmark: BenchLength.original: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
// *** Execute ***
// Launch: 1 / 1
// Execute: dotnet "After.dll" --benchmarkName "FSharp.Perf.BenchLength.original(Size: 1)" --job "After" --benchmarkId 1 in C:\Projects\forks\StringLength-Optimization\StringLengthOptim\bin\Release\netcoreapp3.1\After\bin\LocalBuild\netcoreapp3.1
// BeforeAnythingElse

// Benchmark Process Environment Information:
// Runtime=.NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT DEBUG
// GC=Concurrent Workstation
// Job: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1)

Assembly: "file:///C:/Projects/forks/StringLength-Optimization/StringLengthOptim/bin/Release/netcoreapp3.1/After/bin/LocalBuild/netcoreapp3.1/FSharp.Core.dll"
Version: "42.42.42.42424"
OverheadJitting  1: 10000 op, 292100.00 ns, 29.2100 ns/op
WorkloadJitting  1: 10000 op, 455200.00 ns, 45.5200 ns/op

OverheadJitting  2: 160000 op, 171500.00 ns, 1.0719 ns/op
WorkloadJitting  2: 160000 op, 236600.00 ns, 1.4788 ns/op

WorkloadPilot    1: 160000 op, 89500.00 ns, 0.5594 ns/op
WorkloadPilot    2: 447040000 op, 178664900.00 ns, 0.3997 ns/op
WorkloadPilot    3: 625600000 op, 249599900.00 ns, 0.3990 ns/op
WorkloadPilot    4: 626720000 op, 254990600.00 ns, 0.4069 ns/op
WorkloadPilot    5: 614560000 op, 241683000.00 ns, 0.3933 ns/op
WorkloadPilot    6: 635840000 op, 250878700.00 ns, 0.3946 ns/op
WorkloadPilot    7: 633760000 op, 255017800.00 ns, 0.4024 ns/op

OverheadWarmup   1: 633760000 op, 143800.00 ns, 0.0002 ns/op
OverheadWarmup   2: 633760000 op, 140600.00 ns, 0.0002 ns/op
OverheadWarmup   3: 633760000 op, 139600.00 ns, 0.0002 ns/op
OverheadWarmup   4: 633760000 op, 138300.00 ns, 0.0002 ns/op
OverheadWarmup   5: 633760000 op, 139400.00 ns, 0.0002 ns/op
OverheadWarmup   6: 633760000 op, 140700.00 ns, 0.0002 ns/op
OverheadWarmup   7: 633760000 op, 138300.00 ns, 0.0002 ns/op
OverheadWarmup   8: 633760000 op, 138400.00 ns, 0.0002 ns/op
OverheadWarmup   9: 633760000 op, 139500.00 ns, 0.0002 ns/op
OverheadWarmup  10: 633760000 op, 138400.00 ns, 0.0002 ns/op

OverheadActual   1: 633760000 op, 139400.00 ns, 0.0002 ns/op
OverheadActual   2: 633760000 op, 140500.00 ns, 0.0002 ns/op
OverheadActual   3: 633760000 op, 293200.00 ns, 0.0005 ns/op
OverheadActual   4: 633760000 op, 141300.00 ns, 0.0002 ns/op
OverheadActual   5: 633760000 op, 139500.00 ns, 0.0002 ns/op
OverheadActual   6: 633760000 op, 139300.00 ns, 0.0002 ns/op
OverheadActual   7: 633760000 op, 139300.00 ns, 0.0002 ns/op
OverheadActual   8: 633760000 op, 138400.00 ns, 0.0002 ns/op
OverheadActual   9: 633760000 op, 139400.00 ns, 0.0002 ns/op
OverheadActual  10: 633760000 op, 139300.00 ns, 0.0002 ns/op
OverheadActual  11: 633760000 op, 140100.00 ns, 0.0002 ns/op
OverheadActual  12: 633760000 op, 139400.00 ns, 0.0002 ns/op
OverheadActual  13: 633760000 op, 140400.00 ns, 0.0002 ns/op
OverheadActual  14: 633760000 op, 139500.00 ns, 0.0002 ns/op
OverheadActual  15: 633760000 op, 138400.00 ns, 0.0002 ns/op

WorkloadWarmup   1: 633760000 op, 253651100.00 ns, 0.4002 ns/op

// BeforeActualRun
WorkloadActual   1: 633760000 op, 252714100.00 ns, 0.3988 ns/op
WorkloadActual   2: 633760000 op, 252622000.00 ns, 0.3986 ns/op
WorkloadActual   3: 633760000 op, 252755300.00 ns, 0.3988 ns/op
WorkloadActual   4: 633760000 op, 253550100.00 ns, 0.4001 ns/op
WorkloadActual   5: 633760000 op, 256465100.00 ns, 0.4047 ns/op
WorkloadActual   6: 633760000 op, 256179700.00 ns, 0.4042 ns/op
WorkloadActual   7: 633760000 op, 255008300.00 ns, 0.4024 ns/op
WorkloadActual   8: 633760000 op, 264614600.00 ns, 0.4175 ns/op
WorkloadActual   9: 633760000 op, 255411700.00 ns, 0.4030 ns/op
WorkloadActual  10: 633760000 op, 252671900.00 ns, 0.3987 ns/op
WorkloadActual  11: 633760000 op, 251819200.00 ns, 0.3973 ns/op
WorkloadActual  12: 633760000 op, 249656800.00 ns, 0.3939 ns/op
WorkloadActual  13: 633760000 op, 250236000.00 ns, 0.3948 ns/op
WorkloadActual  14: 633760000 op, 249989700.00 ns, 0.3945 ns/op
WorkloadActual  15: 633760000 op, 249760200.00 ns, 0.3941 ns/op
WorkloadActual  16: 633760000 op, 248996800.00 ns, 0.3929 ns/op
WorkloadActual  17: 633760000 op, 251083000.00 ns, 0.3962 ns/op

// AfterActualRun
WorkloadResult   1: 633760000 op, 252574700.00 ns, 0.3985 ns/op
WorkloadResult   2: 633760000 op, 252482600.00 ns, 0.3984 ns/op
WorkloadResult   3: 633760000 op, 252615900.00 ns, 0.3986 ns/op
WorkloadResult   4: 633760000 op, 253410700.00 ns, 0.3999 ns/op
WorkloadResult   5: 633760000 op, 256325700.00 ns, 0.4045 ns/op
WorkloadResult   6: 633760000 op, 256040300.00 ns, 0.4040 ns/op
WorkloadResult   7: 633760000 op, 254868900.00 ns, 0.4022 ns/op
WorkloadResult   8: 633760000 op, 255272300.00 ns, 0.4028 ns/op
WorkloadResult   9: 633760000 op, 252532500.00 ns, 0.3985 ns/op
WorkloadResult  10: 633760000 op, 251679800.00 ns, 0.3971 ns/op
WorkloadResult  11: 633760000 op, 249517400.00 ns, 0.3937 ns/op
WorkloadResult  12: 633760000 op, 250096600.00 ns, 0.3946 ns/op
WorkloadResult  13: 633760000 op, 249850300.00 ns, 0.3942 ns/op
WorkloadResult  14: 633760000 op, 249620800.00 ns, 0.3939 ns/op
WorkloadResult  15: 633760000 op, 248857400.00 ns, 0.3927 ns/op
WorkloadResult  16: 633760000 op, 250943600.00 ns, 0.3960 ns/op
GC:  0 0 0 5528 633760000
Threading:  2 0 633760000

// AfterAll
// Benchmark Process 2352 has exited with code 0

Mean = 0.398 ns, StdErr = 0.001 ns (0.24%), N = 16, StdDev = 0.004 ns
Min = 0.393 ns, Q1 = 0.395 ns, Median = 0.398 ns, Q3 = 0.400 ns, Max = 0.404 ns
IQR = 0.006 ns, LowerFence = 0.386 ns, UpperFence = 0.409 ns
ConfidenceInterval = [0.394 ns; 0.402 ns] (CI 99.9%), Margin = 0.004 ns (0.97% of Mean)
Skewness = 0.24, Kurtosis = 1.67, MValue = 2

// **************************
// Benchmark: BenchLength.nullOnly: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
// *** Execute ***
// Launch: 1 / 1
// Execute: dotnet "After.dll" --benchmarkName "FSharp.Perf.BenchLength.nullOnly(Size: 1)" --job "After" --benchmarkId 2 in C:\Projects\forks\StringLength-Optimization\StringLengthOptim\bin\Release\netcoreapp3.1\After\bin\LocalBuild\netcoreapp3.1
// BeforeAnythingElse

// Benchmark Process Environment Information:
// Runtime=.NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT DEBUG
// GC=Concurrent Workstation
// Job: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1)

Assembly: "file:///C:/Projects/forks/StringLength-Optimization/StringLengthOptim/bin/Release/netcoreapp3.1/After/bin/LocalBuild/netcoreapp3.1/FSharp.Core.dll"
Version: "42.42.42.42424"
OverheadJitting  1: 10000 op, 293400.00 ns, 29.3400 ns/op
WorkloadJitting  1: 10000 op, 383900.00 ns, 38.3900 ns/op

OverheadJitting  2: 160000 op, 162300.00 ns, 1.0144 ns/op
WorkloadJitting  2: 160000 op, 203500.00 ns, 1.2719 ns/op

WorkloadPilot    1: 160000 op, 45500.00 ns, 0.2844 ns/op
WorkloadPilot    2: 879200000 op, 234308300.00 ns, 0.2665 ns/op
WorkloadPilot    3: 938080000 op, 249855700.00 ns, 0.2663 ns/op
WorkloadPilot    4: 938720000 op, 250001800.00 ns, 0.2663 ns/op

OverheadWarmup   1: 938720000 op, 210900.00 ns, 0.0002 ns/op
OverheadWarmup   2: 938720000 op, 208100.00 ns, 0.0002 ns/op
OverheadWarmup   3: 938720000 op, 207900.00 ns, 0.0002 ns/op
OverheadWarmup   4: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadWarmup   5: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadWarmup   6: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadWarmup   7: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadWarmup   8: 938720000 op, 204700.00 ns, 0.0002 ns/op

OverheadActual   1: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadActual   2: 938720000 op, 206400.00 ns, 0.0002 ns/op
OverheadActual   3: 938720000 op, 206500.00 ns, 0.0002 ns/op
OverheadActual   4: 938720000 op, 206500.00 ns, 0.0002 ns/op
OverheadActual   5: 938720000 op, 207900.00 ns, 0.0002 ns/op
OverheadActual   6: 938720000 op, 206200.00 ns, 0.0002 ns/op
OverheadActual   7: 938720000 op, 206200.00 ns, 0.0002 ns/op
OverheadActual   8: 938720000 op, 208400.00 ns, 0.0002 ns/op
OverheadActual   9: 938720000 op, 371700.00 ns, 0.0004 ns/op
OverheadActual  10: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadActual  11: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadActual  12: 938720000 op, 207100.00 ns, 0.0002 ns/op
OverheadActual  13: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadActual  14: 938720000 op, 206300.00 ns, 0.0002 ns/op
OverheadActual  15: 938720000 op, 206200.00 ns, 0.0002 ns/op

WorkloadWarmup   1: 938720000 op, 250379100.00 ns, 0.2667 ns/op

// BeforeActualRun
WorkloadActual   1: 938720000 op, 250468200.00 ns, 0.2668 ns/op
WorkloadActual   2: 938720000 op, 250099500.00 ns, 0.2664 ns/op
WorkloadActual   3: 938720000 op, 250112200.00 ns, 0.2664 ns/op
WorkloadActual   4: 938720000 op, 250194700.00 ns, 0.2665 ns/op
WorkloadActual   5: 938720000 op, 249650100.00 ns, 0.2659 ns/op
WorkloadActual   6: 938720000 op, 250067700.00 ns, 0.2664 ns/op
WorkloadActual   7: 938720000 op, 249990400.00 ns, 0.2663 ns/op
WorkloadActual   8: 938720000 op, 246975300.00 ns, 0.2631 ns/op
WorkloadActual   9: 938720000 op, 248032900.00 ns, 0.2642 ns/op
WorkloadActual  10: 938720000 op, 245958500.00 ns, 0.2620 ns/op
WorkloadActual  11: 938720000 op, 245901100.00 ns, 0.2620 ns/op
WorkloadActual  12: 938720000 op, 244811600.00 ns, 0.2608 ns/op
WorkloadActual  13: 938720000 op, 245347800.00 ns, 0.2614 ns/op
WorkloadActual  14: 938720000 op, 245987200.00 ns, 0.2620 ns/op
WorkloadActual  15: 938720000 op, 246974100.00 ns, 0.2631 ns/op

// AfterActualRun
WorkloadResult   1: 938720000 op, 250261900.00 ns, 0.2666 ns/op
WorkloadResult   2: 938720000 op, 249893200.00 ns, 0.2662 ns/op
WorkloadResult   3: 938720000 op, 249905900.00 ns, 0.2662 ns/op
WorkloadResult   4: 938720000 op, 249988400.00 ns, 0.2663 ns/op
WorkloadResult   5: 938720000 op, 249443800.00 ns, 0.2657 ns/op
WorkloadResult   6: 938720000 op, 249861400.00 ns, 0.2662 ns/op
WorkloadResult   7: 938720000 op, 249784100.00 ns, 0.2661 ns/op
WorkloadResult   8: 938720000 op, 246769000.00 ns, 0.2629 ns/op
WorkloadResult   9: 938720000 op, 247826600.00 ns, 0.2640 ns/op
WorkloadResult  10: 938720000 op, 245752200.00 ns, 0.2618 ns/op
WorkloadResult  11: 938720000 op, 245694800.00 ns, 0.2617 ns/op
WorkloadResult  12: 938720000 op, 244605300.00 ns, 0.2606 ns/op
WorkloadResult  13: 938720000 op, 245141500.00 ns, 0.2611 ns/op
WorkloadResult  14: 938720000 op, 245780900.00 ns, 0.2618 ns/op
WorkloadResult  15: 938720000 op, 246767800.00 ns, 0.2629 ns/op
GC:  0 0 0 0 938720000
Threading:  2 0 938720000

// AfterAll
// Benchmark Process 30032 has exited with code 0

Mean = 0.264 ns, StdErr = 0.001 ns (0.22%), N = 15, StdDev = 0.002 ns
Min = 0.261 ns, Q1 = 0.262 ns, Median = 0.264 ns, Q3 = 0.266 ns, Max = 0.267 ns
IQR = 0.004 ns, LowerFence = 0.255 ns, UpperFence = 0.273 ns
ConfidenceInterval = [0.262 ns; 0.266 ns] (CI 99.9%), Margin = 0.002 ns (0.91% of Mean)
Skewness = -0.15, Kurtosis = 1.17, MValue = 2

// **************************
// Benchmark: BenchLength.nullRefEq: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
// *** Execute ***
// Launch: 1 / 1
// Execute: dotnet "After.dll" --benchmarkName "FSharp.Perf.BenchLength.nullRefEq(Size: 1)" --job "After" --benchmarkId 3 in C:\Projects\forks\StringLength-Optimization\StringLengthOptim\bin\Release\netcoreapp3.1\After\bin\LocalBuild\netcoreapp3.1
// BeforeAnythingElse

// Benchmark Process Environment Information:
// Runtime=.NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT DEBUG
// GC=Concurrent Workstation
// Job: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1)

Assembly: "file:///C:/Projects/forks/StringLength-Optimization/StringLengthOptim/bin/Release/netcoreapp3.1/After/bin/LocalBuild/netcoreapp3.1/FSharp.Core.dll"
Version: "42.42.42.42424"
OverheadJitting  1: 10000 op, 273500.00 ns, 27.3500 ns/op
WorkloadJitting  1: 10000 op, 413700.00 ns, 41.3700 ns/op

OverheadJitting  2: 160000 op, 172700.00 ns, 1.0794 ns/op
WorkloadJitting  2: 160000 op, 211400.00 ns, 1.3213 ns/op

WorkloadPilot    1: 160000 op, 45800.00 ns, 0.2863 ns/op
WorkloadPilot    2: 873440000 op, 233027000.00 ns, 0.2668 ns/op
WorkloadPilot    3: 937120000 op, 250159500.00 ns, 0.2669 ns/op
WorkloadPilot    4: 936640000 op, 249513600.00 ns, 0.2664 ns/op
WorkloadPilot    5: 938560000 op, 249853000.00 ns, 0.2662 ns/op
WorkloadPilot    6: 939200000 op, 250143900.00 ns, 0.2663 ns/op
WorkloadPilot    7: 938720000 op, 249967300.00 ns, 0.2663 ns/op
WorkloadPilot    8: 938880000 op, 250040400.00 ns, 0.2663 ns/op

OverheadWarmup   1: 938880000 op, 210700.00 ns, 0.0002 ns/op
OverheadWarmup   2: 938880000 op, 215300.00 ns, 0.0002 ns/op
OverheadWarmup   3: 938880000 op, 207800.00 ns, 0.0002 ns/op
OverheadWarmup   4: 938880000 op, 208000.00 ns, 0.0002 ns/op
OverheadWarmup   5: 938880000 op, 206400.00 ns, 0.0002 ns/op

OverheadActual   1: 938880000 op, 213000.00 ns, 0.0002 ns/op
OverheadActual   2: 938880000 op, 207900.00 ns, 0.0002 ns/op
OverheadActual   3: 938880000 op, 207900.00 ns, 0.0002 ns/op
OverheadActual   4: 938880000 op, 213200.00 ns, 0.0002 ns/op
OverheadActual   5: 938880000 op, 207900.00 ns, 0.0002 ns/op
OverheadActual   6: 938880000 op, 204700.00 ns, 0.0002 ns/op
OverheadActual   7: 938880000 op, 206300.00 ns, 0.0002 ns/op
OverheadActual   8: 938880000 op, 207800.00 ns, 0.0002 ns/op
OverheadActual   9: 938880000 op, 206300.00 ns, 0.0002 ns/op
OverheadActual  10: 938880000 op, 204800.00 ns, 0.0002 ns/op
OverheadActual  11: 938880000 op, 207500.00 ns, 0.0002 ns/op
OverheadActual  12: 938880000 op, 206200.00 ns, 0.0002 ns/op
OverheadActual  13: 938880000 op, 206300.00 ns, 0.0002 ns/op
OverheadActual  14: 938880000 op, 206300.00 ns, 0.0002 ns/op
OverheadActual  15: 938880000 op, 207700.00 ns, 0.0002 ns/op

WorkloadWarmup   1: 938880000 op, 250144700.00 ns, 0.2664 ns/op

// BeforeActualRun
WorkloadActual   1: 938880000 op, 250089700.00 ns, 0.2664 ns/op
WorkloadActual   2: 938880000 op, 250559000.00 ns, 0.2669 ns/op
WorkloadActual   3: 938880000 op, 250049400.00 ns, 0.2663 ns/op
WorkloadActual   4: 938880000 op, 249960500.00 ns, 0.2662 ns/op
WorkloadActual   5: 938880000 op, 249178400.00 ns, 0.2654 ns/op
WorkloadActual   6: 938880000 op, 258541900.00 ns, 0.2754 ns/op
WorkloadActual   7: 938880000 op, 245263900.00 ns, 0.2612 ns/op
WorkloadActual   8: 938880000 op, 246312200.00 ns, 0.2623 ns/op
WorkloadActual   9: 938880000 op, 247052900.00 ns, 0.2631 ns/op
WorkloadActual  10: 938880000 op, 246595400.00 ns, 0.2626 ns/op
WorkloadActual  11: 938880000 op, 246548100.00 ns, 0.2626 ns/op
WorkloadActual  12: 938880000 op, 246581400.00 ns, 0.2626 ns/op
WorkloadActual  13: 938880000 op, 246592300.00 ns, 0.2626 ns/op
WorkloadActual  14: 938880000 op, 246419600.00 ns, 0.2625 ns/op
WorkloadActual  15: 938880000 op, 245129800.00 ns, 0.2611 ns/op

// AfterActualRun
WorkloadResult   1: 938880000 op, 249882200.00 ns, 0.2661 ns/op
WorkloadResult   2: 938880000 op, 250351500.00 ns, 0.2666 ns/op
WorkloadResult   3: 938880000 op, 249841900.00 ns, 0.2661 ns/op
WorkloadResult   4: 938880000 op, 249753000.00 ns, 0.2660 ns/op
WorkloadResult   5: 938880000 op, 248970900.00 ns, 0.2652 ns/op
WorkloadResult   6: 938880000 op, 245056400.00 ns, 0.2610 ns/op
WorkloadResult   7: 938880000 op, 246104700.00 ns, 0.2621 ns/op
WorkloadResult   8: 938880000 op, 246845400.00 ns, 0.2629 ns/op
WorkloadResult   9: 938880000 op, 246387900.00 ns, 0.2624 ns/op
WorkloadResult  10: 938880000 op, 246340600.00 ns, 0.2624 ns/op
WorkloadResult  11: 938880000 op, 246373900.00 ns, 0.2624 ns/op
WorkloadResult  12: 938880000 op, 246384800.00 ns, 0.2624 ns/op
WorkloadResult  13: 938880000 op, 246212100.00 ns, 0.2622 ns/op
WorkloadResult  14: 938880000 op, 244922300.00 ns, 0.2609 ns/op
GC:  0 0 0 0 938880000
Threading:  2 0 938880000

// AfterAll
// Benchmark Process 18028 has exited with code 0

Mean = 0.263 ns, StdErr = 0.001 ns (0.21%), N = 14, StdDev = 0.002 ns
Min = 0.261 ns, Q1 = 0.262 ns, Median = 0.262 ns, Q3 = 0.266 ns, Max = 0.267 ns
IQR = 0.004 ns, LowerFence = 0.257 ns, UpperFence = 0.271 ns
ConfidenceInterval = [0.261 ns; 0.266 ns] (CI 99.9%), Margin = 0.002 ns (0.88% of Mean)
Skewness = 0.38, Kurtosis = 1.38, MValue = 2

// **************************
// Benchmark: BenchLength.optimized: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
// *** Execute ***
// Launch: 1 / 1
// Execute: dotnet "Before.dll" --benchmarkName "FSharp.Perf.BenchLength.optimized(Size: 1)" --job "Before" --benchmarkId 0 in C:\Projects\forks\StringLength-Optimization\StringLengthOptim\bin\Release\netcoreapp3.1\Before\bin\Release\netcoreapp3.1
// BeforeAnythingElse

// Benchmark Process Environment Information:
// Runtime=.NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
// GC=Concurrent Workstation
// Job: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1)

Assembly: "file:///C:/Projects/forks/StringLength-Optimization/StringLengthOptim/bin/Release/netcoreapp3.1/Before/bin/Release/netcoreapp3.1/FSharp.Core.dll"
Version: "4.700.20.27008"
OverheadJitting  1: 10000 op, 345300.00 ns, 34.5300 ns/op
WorkloadJitting  1: 10000 op, 483000.00 ns, 48.3000 ns/op

OverheadJitting  2: 160000 op, 229200.00 ns, 1.4325 ns/op
WorkloadJitting  2: 160000 op, 310700.00 ns, 1.9419 ns/op

WorkloadPilot    1: 160000 op, 64100.00 ns, 0.4006 ns/op
WorkloadPilot    2: 624160000 op, 251623300.00 ns, 0.4031 ns/op
WorkloadPilot    3: 620160000 op, 247499600.00 ns, 0.3991 ns/op
WorkloadPilot    4: 626560000 op, 250710700.00 ns, 0.4001 ns/op
WorkloadPilot    5: 624800000 op, 251121300.00 ns, 0.4019 ns/op

OverheadWarmup   1: 624800000 op, 100000.00 ns, 0.0002 ns/op
OverheadWarmup   2: 624800000 op, 97200.00 ns, 0.0002 ns/op
OverheadWarmup   3: 624800000 op, 97200.00 ns, 0.0002 ns/op
OverheadWarmup   4: 624800000 op, 97200.00 ns, 0.0002 ns/op
OverheadWarmup   5: 624800000 op, 97200.00 ns, 0.0002 ns/op
OverheadWarmup   6: 624800000 op, 97200.00 ns, 0.0002 ns/op

OverheadActual   1: 624800000 op, 97200.00 ns, 0.0002 ns/op
OverheadActual   2: 624800000 op, 97200.00 ns, 0.0002 ns/op
OverheadActual   3: 624800000 op, 97200.00 ns, 0.0002 ns/op
OverheadActual   4: 624800000 op, 97100.00 ns, 0.0002 ns/op
OverheadActual   5: 624800000 op, 97200.00 ns, 0.0002 ns/op
OverheadActual   6: 624800000 op, 97200.00 ns, 0.0002 ns/op
OverheadActual   7: 624800000 op, 97100.00 ns, 0.0002 ns/op
OverheadActual   8: 624800000 op, 97200.00 ns, 0.0002 ns/op
OverheadActual   9: 624800000 op, 97200.00 ns, 0.0002 ns/op
OverheadActual  10: 624800000 op, 97100.00 ns, 0.0002 ns/op
OverheadActual  11: 624800000 op, 97200.00 ns, 0.0002 ns/op
OverheadActual  12: 624800000 op, 97200.00 ns, 0.0002 ns/op
OverheadActual  13: 624800000 op, 98700.00 ns, 0.0002 ns/op
OverheadActual  14: 624800000 op, 97200.00 ns, 0.0002 ns/op
OverheadActual  15: 624800000 op, 97200.00 ns, 0.0002 ns/op

WorkloadWarmup   1: 624800000 op, 249544500.00 ns, 0.3994 ns/op

// BeforeActualRun
WorkloadActual   1: 624800000 op, 249294200.00 ns, 0.3990 ns/op
WorkloadActual   2: 624800000 op, 253202600.00 ns, 0.4053 ns/op
WorkloadActual   3: 624800000 op, 252074900.00 ns, 0.4034 ns/op
WorkloadActual   4: 624800000 op, 255455800.00 ns, 0.4089 ns/op
WorkloadActual   5: 624800000 op, 253938800.00 ns, 0.4064 ns/op
WorkloadActual   6: 624800000 op, 249268800.00 ns, 0.3990 ns/op
WorkloadActual   7: 624800000 op, 256922300.00 ns, 0.4112 ns/op
WorkloadActual   8: 624800000 op, 251052800.00 ns, 0.4018 ns/op
WorkloadActual   9: 624800000 op, 254779600.00 ns, 0.4078 ns/op
WorkloadActual  10: 624800000 op, 249624100.00 ns, 0.3995 ns/op
WorkloadActual  11: 624800000 op, 255156500.00 ns, 0.4084 ns/op
WorkloadActual  12: 624800000 op, 250503200.00 ns, 0.4009 ns/op
WorkloadActual  13: 624800000 op, 247315300.00 ns, 0.3958 ns/op
WorkloadActual  14: 624800000 op, 249494400.00 ns, 0.3993 ns/op
WorkloadActual  15: 624800000 op, 245011600.00 ns, 0.3921 ns/op
WorkloadActual  16: 624800000 op, 246517300.00 ns, 0.3946 ns/op
WorkloadActual  17: 624800000 op, 245217100.00 ns, 0.3925 ns/op
WorkloadActual  18: 624800000 op, 245192800.00 ns, 0.3924 ns/op
WorkloadActual  19: 624800000 op, 245736200.00 ns, 0.3933 ns/op
WorkloadActual  20: 624800000 op, 245334200.00 ns, 0.3927 ns/op
WorkloadActual  21: 624800000 op, 244452800.00 ns, 0.3912 ns/op
WorkloadActual  22: 624800000 op, 245265000.00 ns, 0.3925 ns/op
WorkloadActual  23: 624800000 op, 245854800.00 ns, 0.3935 ns/op
WorkloadActual  24: 624800000 op, 249121100.00 ns, 0.3987 ns/op
WorkloadActual  25: 624800000 op, 245626100.00 ns, 0.3931 ns/op
WorkloadActual  26: 624800000 op, 245440500.00 ns, 0.3928 ns/op
WorkloadActual  27: 624800000 op, 245970100.00 ns, 0.3937 ns/op
WorkloadActual  28: 624800000 op, 247263600.00 ns, 0.3957 ns/op
WorkloadActual  29: 624800000 op, 246751800.00 ns, 0.3949 ns/op
WorkloadActual  30: 624800000 op, 246607000.00 ns, 0.3947 ns/op
WorkloadActual  31: 624800000 op, 248535800.00 ns, 0.3978 ns/op

// AfterActualRun
WorkloadResult   1: 624800000 op, 249197000.00 ns, 0.3988 ns/op
WorkloadResult   2: 624800000 op, 253105400.00 ns, 0.4051 ns/op
WorkloadResult   3: 624800000 op, 251977700.00 ns, 0.4033 ns/op
WorkloadResult   4: 624800000 op, 255358600.00 ns, 0.4087 ns/op
WorkloadResult   5: 624800000 op, 253841600.00 ns, 0.4063 ns/op
WorkloadResult   6: 624800000 op, 249171600.00 ns, 0.3988 ns/op
WorkloadResult   7: 624800000 op, 256825100.00 ns, 0.4111 ns/op
WorkloadResult   8: 624800000 op, 250955600.00 ns, 0.4017 ns/op
WorkloadResult   9: 624800000 op, 254682400.00 ns, 0.4076 ns/op
WorkloadResult  10: 624800000 op, 249526900.00 ns, 0.3994 ns/op
WorkloadResult  11: 624800000 op, 255059300.00 ns, 0.4082 ns/op
WorkloadResult  12: 624800000 op, 250406000.00 ns, 0.4008 ns/op
WorkloadResult  13: 624800000 op, 247218100.00 ns, 0.3957 ns/op
WorkloadResult  14: 624800000 op, 249397200.00 ns, 0.3992 ns/op
WorkloadResult  15: 624800000 op, 244914400.00 ns, 0.3920 ns/op
WorkloadResult  16: 624800000 op, 246420100.00 ns, 0.3944 ns/op
WorkloadResult  17: 624800000 op, 245119900.00 ns, 0.3923 ns/op
WorkloadResult  18: 624800000 op, 245095600.00 ns, 0.3923 ns/op
WorkloadResult  19: 624800000 op, 245639000.00 ns, 0.3931 ns/op
WorkloadResult  20: 624800000 op, 245237000.00 ns, 0.3925 ns/op
WorkloadResult  21: 624800000 op, 244355600.00 ns, 0.3911 ns/op
WorkloadResult  22: 624800000 op, 245167800.00 ns, 0.3924 ns/op
WorkloadResult  23: 624800000 op, 245757600.00 ns, 0.3933 ns/op
WorkloadResult  24: 624800000 op, 249023900.00 ns, 0.3986 ns/op
WorkloadResult  25: 624800000 op, 245528900.00 ns, 0.3930 ns/op
WorkloadResult  26: 624800000 op, 245343300.00 ns, 0.3927 ns/op
WorkloadResult  27: 624800000 op, 245872900.00 ns, 0.3935 ns/op
WorkloadResult  28: 624800000 op, 247166400.00 ns, 0.3956 ns/op
WorkloadResult  29: 624800000 op, 246654600.00 ns, 0.3948 ns/op
WorkloadResult  30: 624800000 op, 246509800.00 ns, 0.3945 ns/op
WorkloadResult  31: 624800000 op, 248438600.00 ns, 0.3976 ns/op
GC:  0 0 0 0 624800000
Threading:  2 0 624800000

// AfterAll
// Benchmark Process 17940 has exited with code 0

Mean = 0.398 ns, StdErr = 0.001 ns (0.26%), N = 31, StdDev = 0.006 ns
Min = 0.391 ns, Q1 = 0.393 ns, Median = 0.396 ns, Q3 = 0.401 ns, Max = 0.411 ns
IQR = 0.008 ns, LowerFence = 0.381 ns, UpperFence = 0.413 ns
ConfidenceInterval = [0.394 ns; 0.402 ns] (CI 99.9%), Margin = 0.004 ns (0.96% of Mean)
Skewness = 0.73, Kurtosis = 2.2, MValue = 2

// **************************
// Benchmark: BenchLength.original: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
// *** Execute ***
// Launch: 1 / 1
// Execute: dotnet "Before.dll" --benchmarkName "FSharp.Perf.BenchLength.original(Size: 1)" --job "Before" --benchmarkId 1 in C:\Projects\forks\StringLength-Optimization\StringLengthOptim\bin\Release\netcoreapp3.1\Before\bin\Release\netcoreapp3.1
// BeforeAnythingElse

// Benchmark Process Environment Information:
// Runtime=.NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
// GC=Concurrent Workstation
// Job: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1)

Assembly: "file:///C:/Projects/forks/StringLength-Optimization/StringLengthOptim/bin/Release/netcoreapp3.1/Before/bin/Release/netcoreapp3.1/FSharp.Core.dll"
Version: "4.700.20.27008"
OverheadJitting  1: 10000 op, 351900.00 ns, 35.1900 ns/op
WorkloadJitting  1: 10000 op, 463500.00 ns, 46.3500 ns/op

OverheadJitting  2: 160000 op, 227800.00 ns, 1.4238 ns/op
WorkloadJitting  2: 160000 op, 281000.00 ns, 1.7563 ns/op

WorkloadPilot    1: 160000 op, 64000.00 ns, 0.4000 ns/op
WorkloadPilot    2: 625120000 op, 250048000.00 ns, 0.4000 ns/op

OverheadWarmup   1: 625120000 op, 100200.00 ns, 0.0002 ns/op
OverheadWarmup   2: 625120000 op, 97300.00 ns, 0.0002 ns/op
OverheadWarmup   3: 625120000 op, 102800.00 ns, 0.0002 ns/op
OverheadWarmup   4: 625120000 op, 97300.00 ns, 0.0002 ns/op
OverheadWarmup   5: 625120000 op, 97200.00 ns, 0.0002 ns/op
OverheadWarmup   6: 625120000 op, 97300.00 ns, 0.0002 ns/op
OverheadWarmup   7: 625120000 op, 97200.00 ns, 0.0002 ns/op

OverheadActual   1: 625120000 op, 98700.00 ns, 0.0002 ns/op
OverheadActual   2: 625120000 op, 98800.00 ns, 0.0002 ns/op
OverheadActual   3: 625120000 op, 97300.00 ns, 0.0002 ns/op
OverheadActual   4: 625120000 op, 97300.00 ns, 0.0002 ns/op
OverheadActual   5: 625120000 op, 97200.00 ns, 0.0002 ns/op
OverheadActual   6: 625120000 op, 97200.00 ns, 0.0002 ns/op
OverheadActual   7: 625120000 op, 98800.00 ns, 0.0002 ns/op
OverheadActual   8: 625120000 op, 97300.00 ns, 0.0002 ns/op
OverheadActual   9: 625120000 op, 97300.00 ns, 0.0002 ns/op
OverheadActual  10: 625120000 op, 97300.00 ns, 0.0002 ns/op
OverheadActual  11: 625120000 op, 97300.00 ns, 0.0002 ns/op
OverheadActual  12: 625120000 op, 97200.00 ns, 0.0002 ns/op
OverheadActual  13: 625120000 op, 97300.00 ns, 0.0002 ns/op
OverheadActual  14: 625120000 op, 97300.00 ns, 0.0002 ns/op
OverheadActual  15: 625120000 op, 97300.00 ns, 0.0002 ns/op

WorkloadWarmup   1: 625120000 op, 250572100.00 ns, 0.4008 ns/op

// BeforeActualRun
WorkloadActual   1: 625120000 op, 251983500.00 ns, 0.4031 ns/op
WorkloadActual   2: 625120000 op, 251461600.00 ns, 0.4023 ns/op
WorkloadActual   3: 625120000 op, 249247000.00 ns, 0.3987 ns/op
WorkloadActual   4: 625120000 op, 249190900.00 ns, 0.3986 ns/op
WorkloadActual   5: 625120000 op, 255493700.00 ns, 0.4087 ns/op
WorkloadActual   6: 625120000 op, 263232500.00 ns, 0.4211 ns/op
WorkloadActual   7: 625120000 op, 252118900.00 ns, 0.4033 ns/op
WorkloadActual   8: 625120000 op, 249665100.00 ns, 0.3994 ns/op
WorkloadActual   9: 625120000 op, 258830300.00 ns, 0.4140 ns/op
WorkloadActual  10: 625120000 op, 247616900.00 ns, 0.3961 ns/op
WorkloadActual  11: 625120000 op, 251962000.00 ns, 0.4031 ns/op
WorkloadActual  12: 625120000 op, 249257300.00 ns, 0.3987 ns/op
WorkloadActual  13: 625120000 op, 249766200.00 ns, 0.3995 ns/op
WorkloadActual  14: 625120000 op, 246514800.00 ns, 0.3943 ns/op
WorkloadActual  15: 625120000 op, 246828600.00 ns, 0.3948 ns/op
WorkloadActual  16: 625120000 op, 246516900.00 ns, 0.3944 ns/op
WorkloadActual  17: 625120000 op, 247412400.00 ns, 0.3958 ns/op
WorkloadActual  18: 625120000 op, 247924600.00 ns, 0.3966 ns/op
WorkloadActual  19: 625120000 op, 247180100.00 ns, 0.3954 ns/op

// AfterActualRun
WorkloadResult   1: 625120000 op, 251886200.00 ns, 0.4029 ns/op
WorkloadResult   2: 625120000 op, 251364300.00 ns, 0.4021 ns/op
WorkloadResult   3: 625120000 op, 249149700.00 ns, 0.3986 ns/op
WorkloadResult   4: 625120000 op, 249093600.00 ns, 0.3985 ns/op
WorkloadResult   5: 625120000 op, 255396400.00 ns, 0.4086 ns/op
WorkloadResult   6: 625120000 op, 252021600.00 ns, 0.4032 ns/op
WorkloadResult   7: 625120000 op, 249567800.00 ns, 0.3992 ns/op
WorkloadResult   8: 625120000 op, 247519600.00 ns, 0.3960 ns/op
WorkloadResult   9: 625120000 op, 251864700.00 ns, 0.4029 ns/op
WorkloadResult  10: 625120000 op, 249160000.00 ns, 0.3986 ns/op
WorkloadResult  11: 625120000 op, 249668900.00 ns, 0.3994 ns/op
WorkloadResult  12: 625120000 op, 246417500.00 ns, 0.3942 ns/op
WorkloadResult  13: 625120000 op, 246731300.00 ns, 0.3947 ns/op
WorkloadResult  14: 625120000 op, 246419600.00 ns, 0.3942 ns/op
WorkloadResult  15: 625120000 op, 247315100.00 ns, 0.3956 ns/op
WorkloadResult  16: 625120000 op, 247827300.00 ns, 0.3964 ns/op
WorkloadResult  17: 625120000 op, 247082800.00 ns, 0.3953 ns/op
GC:  0 0 0 0 625120000
Threading:  2 0 625120000

// AfterAll
// Benchmark Process 28012 has exited with code 0

Mean = 0.399 ns, StdErr = 0.001 ns (0.24%), N = 17, StdDev = 0.004 ns
Min = 0.394 ns, Q1 = 0.396 ns, Median = 0.399 ns, Q3 = 0.402 ns, Max = 0.409 ns
IQR = 0.006 ns, LowerFence = 0.386 ns, UpperFence = 0.412 ns
ConfidenceInterval = [0.395 ns; 0.403 ns] (CI 99.9%), Margin = 0.004 ns (0.98% of Mean)
Skewness = 0.72, Kurtosis = 2.66, MValue = 2

// **************************
// Benchmark: BenchLength.nullOnly: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
// *** Execute ***
// Launch: 1 / 1
// Execute: dotnet "Before.dll" --benchmarkName "FSharp.Perf.BenchLength.nullOnly(Size: 1)" --job "Before" --benchmarkId 2 in C:\Projects\forks\StringLength-Optimization\StringLengthOptim\bin\Release\netcoreapp3.1\Before\bin\Release\netcoreapp3.1
// BeforeAnythingElse

// Benchmark Process Environment Information:
// Runtime=.NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
// GC=Concurrent Workstation
// Job: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1)

Assembly: "file:///C:/Projects/forks/StringLength-Optimization/StringLengthOptim/bin/Release/netcoreapp3.1/Before/bin/Release/netcoreapp3.1/FSharp.Core.dll"
Version: "4.700.20.27008"
OverheadJitting  1: 10000 op, 317100.00 ns, 31.7100 ns/op
WorkloadJitting  1: 10000 op, 408900.00 ns, 40.8900 ns/op

OverheadJitting  2: 160000 op, 229700.00 ns, 1.4356 ns/op
WorkloadJitting  2: 160000 op, 269100.00 ns, 1.6819 ns/op

WorkloadPilot    1: 160000 op, 85000.00 ns, 0.5312 ns/op
WorkloadPilot    2: 470720000 op, 139730100.00 ns, 0.2968 ns/op
WorkloadPilot    3: 842240000 op, 235481700.00 ns, 0.2796 ns/op
WorkloadPilot    4: 894240000 op, 239651700.00 ns, 0.2680 ns/op
WorkloadPilot    5: 932960000 op, 276208100.00 ns, 0.2961 ns/op
WorkloadPilot    6: 844480000 op, 250023000.00 ns, 0.2961 ns/op

OverheadWarmup   1: 844480000 op, 134800.00 ns, 0.0002 ns/op
OverheadWarmup   2: 844480000 op, 131300.00 ns, 0.0002 ns/op
OverheadWarmup   3: 844480000 op, 131300.00 ns, 0.0002 ns/op
OverheadWarmup   4: 844480000 op, 136400.00 ns, 0.0002 ns/op
OverheadWarmup   5: 844480000 op, 131200.00 ns, 0.0002 ns/op
OverheadWarmup   6: 844480000 op, 131100.00 ns, 0.0002 ns/op
OverheadWarmup   7: 844480000 op, 131200.00 ns, 0.0002 ns/op

OverheadActual   1: 844480000 op, 131200.00 ns, 0.0002 ns/op
OverheadActual   2: 844480000 op, 131200.00 ns, 0.0002 ns/op
OverheadActual   3: 844480000 op, 131300.00 ns, 0.0002 ns/op
OverheadActual   4: 844480000 op, 131200.00 ns, 0.0002 ns/op
OverheadActual   5: 844480000 op, 131200.00 ns, 0.0002 ns/op
OverheadActual   6: 844480000 op, 131200.00 ns, 0.0002 ns/op
OverheadActual   7: 844480000 op, 131200.00 ns, 0.0002 ns/op
OverheadActual   8: 844480000 op, 131200.00 ns, 0.0002 ns/op
OverheadActual   9: 844480000 op, 131200.00 ns, 0.0002 ns/op
OverheadActual  10: 844480000 op, 131300.00 ns, 0.0002 ns/op
OverheadActual  11: 844480000 op, 131300.00 ns, 0.0002 ns/op
OverheadActual  12: 844480000 op, 131200.00 ns, 0.0002 ns/op
OverheadActual  13: 844480000 op, 131200.00 ns, 0.0002 ns/op
OverheadActual  14: 844480000 op, 131200.00 ns, 0.0002 ns/op
OverheadActual  15: 844480000 op, 131200.00 ns, 0.0002 ns/op

WorkloadWarmup   1: 844480000 op, 254691000.00 ns, 0.3016 ns/op

// BeforeActualRun
WorkloadActual   1: 844480000 op, 241911100.00 ns, 0.2865 ns/op
WorkloadActual   2: 844480000 op, 232130800.00 ns, 0.2749 ns/op
WorkloadActual   3: 844480000 op, 226191300.00 ns, 0.2678 ns/op
WorkloadActual   4: 844480000 op, 264830900.00 ns, 0.3136 ns/op
WorkloadActual   5: 844480000 op, 232980800.00 ns, 0.2759 ns/op
WorkloadActual   6: 844480000 op, 225172500.00 ns, 0.2666 ns/op
WorkloadActual   7: 844480000 op, 226111300.00 ns, 0.2678 ns/op
WorkloadActual   8: 844480000 op, 240048500.00 ns, 0.2843 ns/op
WorkloadActual   9: 844480000 op, 222882600.00 ns, 0.2639 ns/op
WorkloadActual  10: 844480000 op, 223144200.00 ns, 0.2642 ns/op
WorkloadActual  11: 844480000 op, 222066400.00 ns, 0.2630 ns/op
WorkloadActual  12: 844480000 op, 222498700.00 ns, 0.2635 ns/op
WorkloadActual  13: 844480000 op, 222079200.00 ns, 0.2630 ns/op
WorkloadActual  14: 844480000 op, 220207000.00 ns, 0.2608 ns/op
WorkloadActual  15: 844480000 op, 221011000.00 ns, 0.2617 ns/op
WorkloadActual  16: 844480000 op, 220996800.00 ns, 0.2617 ns/op
WorkloadActual  17: 844480000 op, 224057000.00 ns, 0.2653 ns/op
WorkloadActual  18: 844480000 op, 222656100.00 ns, 0.2637 ns/op
WorkloadActual  19: 844480000 op, 223448200.00 ns, 0.2646 ns/op
WorkloadActual  20: 844480000 op, 222551400.00 ns, 0.2635 ns/op
WorkloadActual  21: 844480000 op, 224688200.00 ns, 0.2661 ns/op

// AfterActualRun
WorkloadResult   1: 844480000 op, 226060100.00 ns, 0.2677 ns/op
WorkloadResult   2: 844480000 op, 225041300.00 ns, 0.2665 ns/op
WorkloadResult   3: 844480000 op, 225980100.00 ns, 0.2676 ns/op
WorkloadResult   4: 844480000 op, 222751400.00 ns, 0.2638 ns/op
WorkloadResult   5: 844480000 op, 223013000.00 ns, 0.2641 ns/op
WorkloadResult   6: 844480000 op, 221935200.00 ns, 0.2628 ns/op
WorkloadResult   7: 844480000 op, 222367500.00 ns, 0.2633 ns/op
WorkloadResult   8: 844480000 op, 221948000.00 ns, 0.2628 ns/op
WorkloadResult   9: 844480000 op, 220075800.00 ns, 0.2606 ns/op
WorkloadResult  10: 844480000 op, 220879800.00 ns, 0.2616 ns/op
WorkloadResult  11: 844480000 op, 220865600.00 ns, 0.2615 ns/op
WorkloadResult  12: 844480000 op, 223925800.00 ns, 0.2652 ns/op
WorkloadResult  13: 844480000 op, 222524900.00 ns, 0.2635 ns/op
WorkloadResult  14: 844480000 op, 223317000.00 ns, 0.2644 ns/op
WorkloadResult  15: 844480000 op, 222420200.00 ns, 0.2634 ns/op
WorkloadResult  16: 844480000 op, 224557000.00 ns, 0.2659 ns/op
GC:  0 0 0 0 844480000
Threading:  2 0 844480000

// AfterAll
// Benchmark Process 31080 has exited with code 0

Mean = 0.264 ns, StdErr = 0.001 ns (0.20%), N = 16, StdDev = 0.002 ns
Min = 0.261 ns, Q1 = 0.263 ns, Median = 0.264 ns, Q3 = 0.265 ns, Max = 0.268 ns
IQR = 0.003 ns, LowerFence = 0.259 ns, UpperFence = 0.269 ns
ConfidenceInterval = [0.262 ns; 0.266 ns] (CI 99.9%), Margin = 0.002 ns (0.81% of Mean)
Skewness = 0.27, Kurtosis = 2, MValue = 2

// **************************
// Benchmark: BenchLength.nullRefEq: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
// *** Execute ***
// Launch: 1 / 1
// Execute: dotnet "Before.dll" --benchmarkName "FSharp.Perf.BenchLength.nullRefEq(Size: 1)" --job "Before" --benchmarkId 3 in C:\Projects\forks\StringLength-Optimization\StringLengthOptim\bin\Release\netcoreapp3.1\Before\bin\Release\netcoreapp3.1
// BeforeAnythingElse

// Benchmark Process Environment Information:
// Runtime=.NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
// GC=Concurrent Workstation
// Job: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1)

Assembly: "file:///C:/Projects/forks/StringLength-Optimization/StringLengthOptim/bin/Release/netcoreapp3.1/Before/bin/Release/netcoreapp3.1/FSharp.Core.dll"
Version: "4.700.20.27008"
OverheadJitting  1: 10000 op, 319000.00 ns, 31.9000 ns/op
WorkloadJitting  1: 10000 op, 428100.00 ns, 42.8100 ns/op

OverheadJitting  2: 160000 op, 217400.00 ns, 1.3587 ns/op
WorkloadJitting  2: 160000 op, 257500.00 ns, 1.6094 ns/op

WorkloadPilot    1: 160000 op, 42900.00 ns, 0.2681 ns/op
WorkloadPilot    2: 932480000 op, 250268800.00 ns, 0.2684 ns/op
WorkloadPilot    3: 931520000 op, 273331300.00 ns, 0.2934 ns/op
WorkloadPilot    4: 852160000 op, 239012100.00 ns, 0.2805 ns/op
WorkloadPilot    5: 891360000 op, 236007700.00 ns, 0.2648 ns/op
WorkloadPilot    6: 944320000 op, 261655800.00 ns, 0.2771 ns/op

OverheadWarmup   1: 944320000 op, 150800.00 ns, 0.0002 ns/op
OverheadWarmup   2: 944320000 op, 146700.00 ns, 0.0002 ns/op
OverheadWarmup   3: 944320000 op, 148800.00 ns, 0.0002 ns/op
OverheadWarmup   4: 944320000 op, 146700.00 ns, 0.0002 ns/op
OverheadWarmup   5: 944320000 op, 146700.00 ns, 0.0002 ns/op
OverheadWarmup   6: 944320000 op, 146700.00 ns, 0.0002 ns/op

OverheadActual   1: 944320000 op, 146800.00 ns, 0.0002 ns/op
OverheadActual   2: 944320000 op, 148400.00 ns, 0.0002 ns/op
OverheadActual   3: 944320000 op, 148300.00 ns, 0.0002 ns/op
OverheadActual   4: 944320000 op, 146800.00 ns, 0.0002 ns/op
OverheadActual   5: 944320000 op, 146700.00 ns, 0.0002 ns/op
OverheadActual   6: 944320000 op, 146700.00 ns, 0.0002 ns/op
OverheadActual   7: 944320000 op, 146700.00 ns, 0.0002 ns/op
OverheadActual   8: 944320000 op, 146800.00 ns, 0.0002 ns/op
OverheadActual   9: 944320000 op, 146800.00 ns, 0.0002 ns/op
OverheadActual  10: 944320000 op, 146800.00 ns, 0.0002 ns/op
OverheadActual  11: 944320000 op, 146800.00 ns, 0.0002 ns/op
OverheadActual  12: 944320000 op, 146700.00 ns, 0.0002 ns/op
OverheadActual  13: 944320000 op, 146700.00 ns, 0.0002 ns/op
OverheadActual  14: 944320000 op, 146800.00 ns, 0.0002 ns/op
OverheadActual  15: 944320000 op, 146800.00 ns, 0.0002 ns/op

WorkloadWarmup   1: 944320000 op, 251889400.00 ns, 0.2667 ns/op

// BeforeActualRun
WorkloadActual   1: 944320000 op, 250072800.00 ns, 0.2648 ns/op
WorkloadActual   2: 944320000 op, 296840100.00 ns, 0.3143 ns/op
WorkloadActual   3: 944320000 op, 273508500.00 ns, 0.2896 ns/op
WorkloadActual   4: 944320000 op, 320885300.00 ns, 0.3398 ns/op
WorkloadActual   5: 944320000 op, 267968900.00 ns, 0.2838 ns/op
WorkloadActual   6: 944320000 op, 309187400.00 ns, 0.3274 ns/op
WorkloadActual   7: 944320000 op, 252904500.00 ns, 0.2678 ns/op
WorkloadActual   8: 944320000 op, 250010200.00 ns, 0.2648 ns/op
WorkloadActual   9: 944320000 op, 249616200.00 ns, 0.2643 ns/op
WorkloadActual  10: 944320000 op, 249308900.00 ns, 0.2640 ns/op
WorkloadActual  11: 944320000 op, 247814800.00 ns, 0.2624 ns/op
WorkloadActual  12: 944320000 op, 248099700.00 ns, 0.2627 ns/op
WorkloadActual  13: 944320000 op, 250492900.00 ns, 0.2653 ns/op
WorkloadActual  14: 944320000 op, 248646500.00 ns, 0.2633 ns/op
WorkloadActual  15: 944320000 op, 248339900.00 ns, 0.2630 ns/op
WorkloadActual  16: 944320000 op, 247678200.00 ns, 0.2623 ns/op
WorkloadActual  17: 944320000 op, 250692700.00 ns, 0.2655 ns/op
WorkloadActual  18: 944320000 op, 249133700.00 ns, 0.2638 ns/op
WorkloadActual  19: 944320000 op, 250741500.00 ns, 0.2655 ns/op
WorkloadActual  20: 944320000 op, 249477200.00 ns, 0.2642 ns/op
WorkloadActual  21: 944320000 op, 248899500.00 ns, 0.2636 ns/op

// AfterActualRun
WorkloadResult   1: 944320000 op, 249926000.00 ns, 0.2647 ns/op
WorkloadResult   2: 944320000 op, 252757700.00 ns, 0.2677 ns/op
WorkloadResult   3: 944320000 op, 249863400.00 ns, 0.2646 ns/op
WorkloadResult   4: 944320000 op, 249469400.00 ns, 0.2642 ns/op
WorkloadResult   5: 944320000 op, 249162100.00 ns, 0.2639 ns/op
WorkloadResult   6: 944320000 op, 247668000.00 ns, 0.2623 ns/op
WorkloadResult   7: 944320000 op, 247952900.00 ns, 0.2626 ns/op
WorkloadResult   8: 944320000 op, 250346100.00 ns, 0.2651 ns/op
WorkloadResult   9: 944320000 op, 248499700.00 ns, 0.2632 ns/op
WorkloadResult  10: 944320000 op, 248193100.00 ns, 0.2628 ns/op
WorkloadResult  11: 944320000 op, 247531400.00 ns, 0.2621 ns/op
WorkloadResult  12: 944320000 op, 250545900.00 ns, 0.2653 ns/op
WorkloadResult  13: 944320000 op, 248986900.00 ns, 0.2637 ns/op
WorkloadResult  14: 944320000 op, 250594700.00 ns, 0.2654 ns/op
WorkloadResult  15: 944320000 op, 249330400.00 ns, 0.2640 ns/op
WorkloadResult  16: 944320000 op, 248752700.00 ns, 0.2634 ns/op
GC:  0 0 0 568 944320000
Threading:  2 0 944320000

// AfterAll
// Benchmark Process 25136 has exited with code 0

Mean = 0.264 ns, StdErr = 0.000 ns (0.13%), N = 16, StdDev = 0.001 ns
Min = 0.262 ns, Q1 = 0.263 ns, Median = 0.264 ns, Q3 = 0.265 ns, Max = 0.268 ns
IQR = 0.002 ns, LowerFence = 0.261 ns, UpperFence = 0.267 ns
ConfidenceInterval = [0.263 ns; 0.265 ns] (CI 99.9%), Margin = 0.001 ns (0.55% of Mean)
Skewness = 0.75, Kurtosis = 3.23, MValue = 2

// ***** BenchmarkRunner: Finish  *****

// * Export *
  BenchmarkDotNet.Artifacts\results\FSharp.Perf.BenchLength-report.csv
  BenchmarkDotNet.Artifacts\results\FSharp.Perf.BenchLength-report-github.md
  BenchmarkDotNet.Artifacts\results\FSharp.Perf.BenchLength-report.html
  BenchmarkDotNet.Artifacts\results\FSharp.Perf.BenchLength-asm.md

// * Detailed results *
BenchLength.optimized: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
Runtime = .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT DEBUG; GC = Concurrent Workstation
Mean = 0.264 ns, StdErr = 0.001 ns (0.20%), N = 15, StdDev = 0.002 ns
Min = 0.262 ns, Q1 = 0.263 ns, Median = 0.264 ns, Q3 = 0.266 ns, Max = 0.267 ns
IQR = 0.003 ns, LowerFence = 0.258 ns, UpperFence = 0.271 ns
ConfidenceInterval = [0.262 ns; 0.267 ns] (CI 99.9%), Margin = 0.002 ns (0.82% of Mean)
Skewness = 0.01, Kurtosis = 1.13, MValue = 2
-------------------- Histogram --------------------
[0.261 ns ; 0.268 ns) | @@@@@@@@@@@@@@@
---------------------------------------------------

BenchLength.original: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
Runtime = .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT DEBUG; GC = Concurrent Workstation
Mean = 0.398 ns, StdErr = 0.001 ns (0.24%), N = 16, StdDev = 0.004 ns
Min = 0.393 ns, Q1 = 0.395 ns, Median = 0.398 ns, Q3 = 0.400 ns, Max = 0.404 ns
IQR = 0.006 ns, LowerFence = 0.386 ns, UpperFence = 0.409 ns
ConfidenceInterval = [0.394 ns; 0.402 ns] (CI 99.9%), Margin = 0.004 ns (0.97% of Mean)
Skewness = 0.24, Kurtosis = 1.67, MValue = 2
-------------------- Histogram --------------------
[0.391 ns ; 0.407 ns) | @@@@@@@@@@@@@@@@
---------------------------------------------------

BenchLength.nullOnly: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
Runtime = .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT DEBUG; GC = Concurrent Workstation
Mean = 0.264 ns, StdErr = 0.001 ns (0.22%), N = 15, StdDev = 0.002 ns
Min = 0.261 ns, Q1 = 0.262 ns, Median = 0.264 ns, Q3 = 0.266 ns, Max = 0.267 ns
IQR = 0.004 ns, LowerFence = 0.255 ns, UpperFence = 0.273 ns
ConfidenceInterval = [0.262 ns; 0.266 ns] (CI 99.9%), Margin = 0.002 ns (0.91% of Mean)
Skewness = -0.15, Kurtosis = 1.17, MValue = 2
-------------------- Histogram --------------------
[0.259 ns ; 0.268 ns) | @@@@@@@@@@@@@@@
---------------------------------------------------

BenchLength.nullRefEq: After(MaxRelativeError=0.01, BuildConfiguration=LocalBuild, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
Runtime = .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT DEBUG; GC = Concurrent Workstation
Mean = 0.263 ns, StdErr = 0.001 ns (0.21%), N = 14, StdDev = 0.002 ns
Min = 0.261 ns, Q1 = 0.262 ns, Median = 0.262 ns, Q3 = 0.266 ns, Max = 0.267 ns
IQR = 0.004 ns, LowerFence = 0.257 ns, UpperFence = 0.271 ns
ConfidenceInterval = [0.261 ns; 0.266 ns] (CI 99.9%), Margin = 0.002 ns (0.88% of Mean)
Skewness = 0.38, Kurtosis = 1.38, MValue = 2
-------------------- Histogram --------------------
[0.260 ns ; 0.268 ns) | @@@@@@@@@@@@@@
---------------------------------------------------

BenchLength.optimized: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
Runtime = .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT; GC = Concurrent Workstation
Mean = 0.398 ns, StdErr = 0.001 ns (0.26%), N = 31, StdDev = 0.006 ns
Min = 0.391 ns, Q1 = 0.393 ns, Median = 0.396 ns, Q3 = 0.401 ns, Max = 0.411 ns
IQR = 0.008 ns, LowerFence = 0.381 ns, UpperFence = 0.413 ns
ConfidenceInterval = [0.394 ns; 0.402 ns] (CI 99.9%), Margin = 0.004 ns (0.96% of Mean)
Skewness = 0.73, Kurtosis = 2.2, MValue = 2
-------------------- Histogram --------------------
[0.389 ns ; 0.404 ns) | @@@@@@@@@@@@@@@@@@@@@@@@@
[0.404 ns ; 0.414 ns) | @@@@@@
---------------------------------------------------

BenchLength.original: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
Runtime = .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT; GC = Concurrent Workstation
Mean = 0.399 ns, StdErr = 0.001 ns (0.24%), N = 17, StdDev = 0.004 ns
Min = 0.394 ns, Q1 = 0.396 ns, Median = 0.399 ns, Q3 = 0.402 ns, Max = 0.409 ns
IQR = 0.006 ns, LowerFence = 0.386 ns, UpperFence = 0.412 ns
ConfidenceInterval = [0.395 ns; 0.403 ns] (CI 99.9%), Margin = 0.004 ns (0.98% of Mean)
Skewness = 0.72, Kurtosis = 2.66, MValue = 2
-------------------- Histogram --------------------
[0.394 ns ; 0.411 ns) | @@@@@@@@@@@@@@@@@
---------------------------------------------------

BenchLength.nullOnly: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
Runtime = .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT; GC = Concurrent Workstation
Mean = 0.264 ns, StdErr = 0.001 ns (0.20%), N = 16, StdDev = 0.002 ns
Min = 0.261 ns, Q1 = 0.263 ns, Median = 0.264 ns, Q3 = 0.265 ns, Max = 0.268 ns
IQR = 0.003 ns, LowerFence = 0.259 ns, UpperFence = 0.269 ns
ConfidenceInterval = [0.262 ns; 0.266 ns] (CI 99.9%), Margin = 0.002 ns (0.81% of Mean)
Skewness = 0.27, Kurtosis = 2, MValue = 2
-------------------- Histogram --------------------
[0.260 ns ; 0.269 ns) | @@@@@@@@@@@@@@@@
---------------------------------------------------

BenchLength.nullRefEq: Before(MaxRelativeError=0.01, IterationTime=250.0000 ms, WarmupCount=1) [Size=1]
Runtime = .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT; GC = Concurrent Workstation
Mean = 0.264 ns, StdErr = 0.000 ns (0.13%), N = 16, StdDev = 0.001 ns
Min = 0.262 ns, Q1 = 0.263 ns, Median = 0.264 ns, Q3 = 0.265 ns, Max = 0.268 ns
IQR = 0.002 ns, LowerFence = 0.261 ns, UpperFence = 0.267 ns
ConfidenceInterval = [0.263 ns; 0.265 ns] (CI 99.9%), Margin = 0.001 ns (0.55% of Mean)
Skewness = 0.75, Kurtosis = 3.23, MValue = 2
-------------------- Histogram --------------------
[0.261 ns ; 0.269 ns) | @@@@@@@@@@@@@@@@
---------------------------------------------------

// * Summary *

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.900 (1909/November2018Update/19H2)
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.100-preview.7.20319.6
  [Host] : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT DEBUG
  After  : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT DEBUG
  Before : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT

MaxRelativeError=0.01  IterationTime=250.0000 ms  WarmupCount=1

|    Method |    Job | BuildConfiguration | Size |      Mean |     Error |    StdDev | Ratio | Rank | Code Size | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |------- |------------------- |----- |----------:|----------:|----------:|------:|-----:|----------:|------:|------:|------:|----------:|
| optimized |  After |         LocalBuild |    1 | 0.2644 ns | 0.0022 ns | 0.0020 ns |  1.00 |    1 |     217 B |     - |     - |     - |         - |
|  original |  After |         LocalBuild |    1 | 0.3981 ns | 0.0039 ns | 0.0038 ns |  1.51 |    2 |     223 B |     - |     - |     - |         - |
|  nullOnly |  After |         LocalBuild |    1 | 0.2640 ns | 0.0024 ns | 0.0023 ns |  1.00 |    1 |     217 B |     - |     - |     - |         - |
| nullRefEq |  After |         LocalBuild |    1 | 0.2635 ns | 0.0023 ns | 0.0020 ns |  1.00 |    1 |     217 B |     - |     - |     - |         - |
|           |        |                    |      |           |           |           |       |      |           |       |       |       |           |
| optimized | Before |            Default |    1 | 0.3980 ns | 0.0038 ns | 0.0059 ns |  1.00 |    2 |     223 B |     - |     - |     - |         - |
|  original | Before |            Default |    1 | 0.3988 ns | 0.0039 ns | 0.0040 ns |  0.99 |    2 |     223 B |     - |     - |     - |         - |
|  nullOnly | Before |            Default |    1 | 0.2640 ns | 0.0021 ns | 0.0021 ns |  0.66 |    1 |     217 B |     - |     - |     - |         - |
| nullRefEq | Before |            Default |    1 | 0.2641 ns | 0.0014 ns | 0.0014 ns |  0.66 |    1 |     217 B |     - |     - |     - |         - |

// * Hints *
Outliers
  BenchLength.original: After   -> 1 outlier  was  removed (0.42 ns)
  BenchLength.nullRefEq: After  -> 1 outlier  was  removed (0.28 ns)
  BenchLength.original: Before  -> 2 outliers were removed (0.41 ns, 0.42 ns)
  BenchLength.nullOnly: Before  -> 5 outliers were removed (0.27 ns..0.31 ns)
  BenchLength.nullRefEq: Before -> 5 outliers were removed (0.28 ns..0.34 ns)

// * Legends *
  Size      : Value of the 'Size' parameter
  Mean      : Arithmetic mean of all measurements
  Error     : Half of 99.9% confidence interval
  StdDev    : Standard deviation of all measurements
  Ratio     : Mean of the ratio distribution ([Current]/[Baseline])
  Rank      : Relative position of current benchmark mean among all benchmarks (Arabic style)
  Code Size : Native code size of the disassembled method(s)
  Gen 0     : GC Generation 0 collects per 1000 operations
  Gen 1     : GC Generation 1 collects per 1000 operations
  Gen 2     : GC Generation 2 collects per 1000 operations
  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
  1 ns      : 1 Nanosecond (0.000000001 sec)

// * Diagnostic Output - MemoryDiagnoser *

// * Diagnostic Output - DisassemblyDiagnoser *
Disassembled benchmarks got exported to ".\BenchmarkDotNet.Artifacts\results\*asm.md"

// ***** BenchmarkRunner: End *****
// ** Remained 0 benchmark(s) to run **
Run time: 00:00:59 (60 sec), executed benchmarks: 8

Global total time: 00:01:17 (77.51 sec), executed benchmarks: 8
// * Artifacts cleanup *
```

</details>
